### PR TITLE
[기능구현] 리프레쉬 토큰 구현완료, 구글/카카오 70% 구현완료

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,7 +10,7 @@ import { ConfigModule } from '@nestjs/config';
 import { PlayerRepository } from 'src/players/players.repository';
 import { GoogleStrategy } from './google/google.strategy';
 import { KakaoStrategy } from './kakao/kakao-strategy';
-import { SessionSerializer } from './session/session.seralizer';
+// import { SessionSerializer } from './session/session.seralizer';
 import { PassportModule } from '@nestjs/passport';
 import { JwtRefreshTokenStrategy } from './jwt/jwt-refresh-strategy';
 

--- a/src/auth/google/google.strategy.ts
+++ b/src/auth/google/google.strategy.ts
@@ -1,44 +1,37 @@
-import { CreateLikeDto } from './../../likes/dto/create-like.dto';
-// import { AuthService } from '../auth.service';
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy, VerifyCallback } from 'passport-google-oauth20';
+import { Strategy, Profile, VerifyCallback } from 'passport-google-oauth20';
 import * as config from 'config';
 
 const googleConfig = config.get('google');
 
 @Injectable()
-export class GoogleStrategy extends PassportStrategy(Strategy) {
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   constructor() {
     super({
       clientID: googleConfig.clientId,
       clientSecret: googleConfig.clientSecret,
-      callbackURL: '/players/redirect',
+      callbackURL: '/api/players/googleauth',
       passReqToCallback: true,
       scope: ['profile', 'email'],
     });
   }
   // 인증이 되어 있나 감시
   async validate(
-    accessToken: string,
-    refreshToken: string,
+    _accessToken: string,
+    _refreshToken: string,
     profile: any,
-    Done: VerifyCallback
+    req: any
   ): Promise<any> {
-    console.log(googleConfig.clientId);
-    console.log(googleConfig.clientSecret);
-    // console.log(accessToken);
-    try {
-      console.log(profile);
-      const { emails, photos } = profile;
-      const player = {
-        email: emails[0].value,
-        profileImg: photos[0].value,
-        accessToken,
-      };
-      Done(null, player);
-    } catch (err) {
-      console.log(err);
-    }
+    const { id, emails, disaplayName } = req;
+    console.log(req);
+
+    console.log(profile);
+    return {
+      provider: 'google',
+      providerId: id,
+      nickname: disaplayName,
+      email: emails[0].value,
+    };
   }
 }

--- a/src/auth/jwt/jwt-refresh-strategy.ts
+++ b/src/auth/jwt/jwt-refresh-strategy.ts
@@ -22,39 +22,35 @@ export class JwtRefreshTokenStrategy extends PassportStrategy(
     private readonly authService: AuthService,
     private readonly playersService: PlayersService
   ) {
-    console.log('hello');
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
           const token = request.headers['cookies'];
           let tokenValue = '';
           if (typeof token === 'string') tokenValue = token.split(' ')[1];
-          console.log(tokenValue);
           return tokenValue;
         },
       ]),
       secretOrKey: jwtConfig.refreshSecret,
       passReqToCallback: true,
-      // ignoreExpiration: false,
+      ignoreExpiration: false,
     });
   }
 
   // 위에서 return된 tokenValue를 통해 유저 정보를 decode 하고 payload로 반환된다.
   async validate(request: Request, payload: TokenPayloadDto) {
-    console.log(payload);
-    const { id, email, nickname } = payload;
-    const data = await this.playersService.getRefreshToken(id);
-    console.log(data);
-  }
+    const { id, nickname, email } = payload;
 
-  //   async validate(payload: any) {
-  //     return {
-  //       ok: true,
-  //       player: {
-  //         playerId: payload.id,
-  //         email: payload.email,
-  //         nickname: payload.nickname,
-  //       },
-  //     };
-  //   }
+    const token = request.headers['cookies'];
+    let tokenValue = '';
+    if (typeof token === 'string') tokenValue = token.split(' ')[1];
+
+    const getData = await this.authService.checkRefreshToken(id, tokenValue);
+
+    if (!getData) {
+      return false;
+    }
+
+    return payload;
+  }
 }

--- a/src/auth/kakao/kakao-strategy.ts
+++ b/src/auth/kakao/kakao-strategy.ts
@@ -2,16 +2,17 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-kakao';
 import * as config from 'config';
+import { AuthService } from '../auth.service';
 
 const kakaoConfig = config.get('kakao');
 
 @Injectable()
 export class KakaoStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(private readonly authService: AuthService) {
     super({
       clientID: kakaoConfig.clientId,
       clientSecret: kakaoConfig.clientSecret,
-      callbackURL: '/players/kakaoredirect',
+      callbackURL: '/api/players/kakaoauth',
       //   scope: ['profile'],
     });
   }
@@ -25,13 +26,34 @@ export class KakaoStrategy extends PassportStrategy(Strategy) {
     const { id, username } = profile;
     const { profile_image, thumbnail_image } = profile._json.properties;
 
+    console.log(profile);
+    // DB조회 후 없으면 DB저장
+    // 저장될  provier id, provider, provider_id, email, nickname, profile_image, thumbnail_image
+    // if (id) {
+    // const hello = await this.authService.kakaoLogin(
+    //   email,
+    //   username,
+    //   profile_image,
+    //   'kakao',
+    //   id
+    // );
+
+    //   return hello;
+    // }
+
+    // const player = await this.authService.findOrCreatePlayer(
+
     const player = {
-      id: id,
-      username: username,
+      id,
+      username,
       profileImg: profile_image,
       thumbnailImg: thumbnail_image,
       accessToken: access_token,
+      refreshToken: refreshToken,
     };
+
+    console.log(player);
     Done(null, player);
+    return player;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,14 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as config from 'config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import * as session from 'express-session';
-import * as passport from 'passport';
+// import * as session from 'express-session';
+// import * as passport from 'passport';
 
 async function bootstrap() {
   const logger = new Logger();
   const app = await NestFactory.create(AppModule, { cors: true });
   const serverConfig = config.get('server');
-  const developmentConfig = config.get('jwt');
+  // const developmentConfig = config.get('jwt');
 
   app.enableCors({
     origin: '*',
@@ -31,7 +31,6 @@ async function bootstrap() {
 
   // app.use(passport.initialize());
   // app.use(passport.session());
-
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/src/players/dto/create-player.dto.ts
+++ b/src/players/dto/create-player.dto.ts
@@ -24,7 +24,7 @@ export class CreatePlayerDto {
   provider: string;
 
   @IsNotEmpty()
-  providerId: string;
+  providerId: number;
 
   @IsNotEmpty()
   currentHashedRefreshToken: string;

--- a/src/players/players.repository.ts
+++ b/src/players/players.repository.ts
@@ -1,7 +1,7 @@
 import { EntityRepository, Repository } from 'typeorm';
-import { Complete } from 'src/quests/entities/complete.entity';
 import {
   CreateBodyDto,
+  CreateLocalDto,
   EmailDto,
   NicknameDto,
   UpdateInfoDto,
@@ -69,7 +69,7 @@ export class PlayerRepository extends Repository<Player> {
   }
 
   //토큰 관련 Repository
-  async updateRefreshToken(id: number, refreshToken: string): Promise<any> {
+  async saveRefreshToken(id: number, refreshToken: string): Promise<any> {
     try {
       const currentHashedRefreshToken = await bcrypt.hash(refreshToken, 10);
       const result = await this.update(id, { currentHashedRefreshToken });
@@ -85,7 +85,48 @@ export class PlayerRepository extends Repository<Player> {
         select: ['currentHashedRefreshToken'],
         where: { id },
       });
-      return result
+      return result;
+    } catch (err) {
+      return err.message;
+    }
+  }
+  async deleteToken(id: number): Promise<any> {
+    try {
+      const result = await this.update(id, { currentHashedRefreshToken: null });
+      return result;
+    } catch (err) {
+      return err.message;
+    }
+  }
+
+  async findOrCreatePlayer(createLocalDto: CreateLocalDto): Promise<object> {
+    try {
+      const {
+        email,
+        password,
+        nickname,
+        mbti,
+        profileImg,
+        provider,
+        providerId,
+      } = createLocalDto;
+
+      console.log('저장하나');
+      const createPlayer = await this.create({
+        email,
+        nickname,
+        mbti,
+        profileImg,
+        provider,
+        providerId,
+      });
+      console.log('saved');
+
+      console.log(createPlayer);
+      const result = await this.save(createPlayer);
+      console.log(result);
+
+      // return await this.save(createPlayer);
     } catch (err) {
       return err.message;
     }
@@ -93,7 +134,7 @@ export class PlayerRepository extends Repository<Player> {
 
   // 경도 위도 가져와서 mypage에 보내줄거
   async locations(id2: number): Promise<any> {
-    const id = 2;
+    const id = id2;
     try {
       const result = await this.createQueryBuilder('player')
         // .select([
@@ -120,25 +161,4 @@ export class PlayerRepository extends Repository<Player> {
       return err.message;
     }
   }
-
-  //     const locations = await this.find({
-  //       order: { id: 'DESC' },
-  //       relations: ['completes', 'completes.quest'],
-  //       select: [
-  //         'id',
-  //         'nickname',
-  //         'profileImg',
-  //         'mbti',
-  //         'level',
-  //         'exp',
-  //         'completes',
-  //         // 'completes.quest.id',
-  //       ],
-  //     });
-
-  //     return locations;
-  //   } catch (err) {
-  //     return err.message;
-  //   }
-  // }
 }

--- a/src/players/players.service.ts
+++ b/src/players/players.service.ts
@@ -91,9 +91,9 @@ export class PlayersService {
     try {
       console.log(playerId);
       const result = await this.playersRepository.checkRefreshToken(playerId);
-      console.log("-0-------")
+      console.log('-0-------');
       console.log(result);
-      console.log("-0-------")
+      console.log('-0-------');
       return result;
     } catch (err) {
       console.log(err.message);


### PR DESCRIPTION
## Description (개요)
리프레쉬 토큰 구현완료
엑세스 토큰은 쿠키로 백에서 삽입,
리프레쉬 토큰은 헤더로 보내집니다.

구글/카카오는 70% 구현완료
처음 로그인을 했을 DB에 저장되면, 가입 
DB에 기록이 있으면 로그인 토큰 발급 부분 연결 하면됩니다.

